### PR TITLE
fix: early-exit if no keydown event key exists

### DIFF
--- a/src/ngx-google-places-autocomplete.directive.ts
+++ b/src/ngx-google-places-autocomplete.directive.ts
@@ -46,6 +46,10 @@ export class GooglePlaceDirective implements AfterViewInit {
         }
 
         this.el.nativeElement.addEventListener('keydown', (event: KeyboardEvent) => {
+            if(!event.key) {
+                return;
+            }
+
             let key = event.key.toLowerCase();
 
             if (key == 'enter' && event.target === this.el.nativeElement) {


### PR DESCRIPTION
We're having issues with Google Chrome's autofill putting an address into the autocomplete input and upon change detection occurring, it triggers a `keydown` event with no `key`.  In result we get a type error due to no `event.key` being available when `toLowerCase()` is called.  My solution simply guards the eventListener functionality from executing when `event.key` does not exist. 