### PR TITLE
fix(directive): early-exit if no keydown event key exists

### DIFF
--- a/src/ngx-google-places-autocomplete.directive.ts
+++ b/src/ngx-google-places-autocomplete.directive.ts
@@ -46,6 +46,10 @@ export class GooglePlaceDirective implements AfterViewInit {
         }
 
         this.el.nativeElement.addEventListener('keydown', (event: KeyboardEvent) => {
+            if(!event.key) {
+                return;
+            }
+            
             let key = event.key.toLowerCase();
 
             if (key == 'enter' && event.target === this.el.nativeElement) {


### PR DESCRIPTION
Early exit if no `key` in `keydown` event exists.  (Autofill emits `keydown` without a key)