### PR TITLE
Update ngx-google-places-autocomplete.directive.ts

### DIFF
--- a/src/ngx-google-places-autocomplete.directive.ts
+++ b/src/ngx-google-places-autocomplete.directive.ts
@@ -91,7 +91,7 @@ export class GooglePlaceDirective implements AfterViewInit {
         this.ngZone.run(() => {
             this.place = this.autocomplete.getPlace();
 
-            if (this.place && this.place.place_id) {
+            if (this.place) {
                 this.onAddressChange.emit(this.place);
             }
         });


### PR DESCRIPTION
Place should be returned even if place_id is missing when selecting specific fields