### PR TITLE
Allow an array of string in ComponentRestrictions

### DIFF
--- a/src/objects/options/componentRestrictions.ts
+++ b/src/objects/options/componentRestrictions.ts
@@ -1,5 +1,5 @@
 export class ComponentRestrictions {
-    public country: string;
+    public country: string|string[];
 
     constructor(obj?: Partial<ComponentRestrictions>) {
         if (!obj)

--- a/src/objects/options/options.ts
+++ b/src/objects/options/options.ts
@@ -3,12 +3,12 @@ import { LatLngBounds } from "../latLngBounds";
 import { ComponentRestrictions } from "./componentRestrictions";
 
 export class Options {
-    public bounds: LatLngBounds;
-    public componentRestrictions: ComponentRestrictions;
-    public types: string[];
-    public fields: string[];
-    public strictBounds: boolean;
-    public origin: LatLng;
+    public bounds?: LatLngBounds;
+    public componentRestrictions?: ComponentRestrictions;
+    public types?: string[];
+    public fields?: string[];
+    public strictBounds?: boolean;
+    public origin?: LatLng;
     public constructor(opt?: Partial<Options>) {
         if (!opt)
             return;


### PR DESCRIPTION
As the google doc says, it should be allowed to have an array here. 
See https://developers.google.com/maps/documentation/javascript/reference/places-autocomplete-service#ComponentRestrictions

Why I'm proposing this change:
With the new updates to the language server, I added `"angularCompilerOptions":{ "strictTemplates":true  }` to my tsconfig which now throws an error like :
```
error TS2739: Type '{ componentRestrictions: { country: string[]; }; types: string[]; }' is missing the following properties from type 'Options': bounds, fields, strictBounds, origin
38         [options]="options"
```
Since I had in my code : (screenshot to see the reason of the error)
![image](https://user-images.githubusercontent.com/10205672/109512296-3fe30580-7aa4-11eb-9fb3-8e55562ca60f.png)

