### PR TITLE
Added missing string array type for 'country' property

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "ngx-google-places-autocomplete",
   "version": "2.0.5",
   "scripts": {
+    "prepare": "yarn build",
     "start": "tsc -p example && tsc -p src && concurrently \"tsc -p example -w\" \"tsc -p src -w\" \"lite-server --config sync-bs-config.json\" ",
     "yarn": "yarn",
     "build": "yarn run clean && ngc -p src/tsconfig.webpack.json && rollup -c rollup.config.js",

--- a/src/objects/options/componentRestrictions.ts
+++ b/src/objects/options/componentRestrictions.ts
@@ -1,5 +1,5 @@
 export class ComponentRestrictions {
-    public country: string;
+    public country: string | string[];
 
     constructor(obj?: Partial<ComponentRestrictions>) {
         if (!obj)


### PR DESCRIPTION
As per the [documentation](https://developers.google.com/maps/documentation/javascript/reference/places-autocomplete-service#ComponentRestrictions), `google.maps.places.ComponentRestrictions.country` is of `Type:  string|Array<string> optional`.