### PR TITLE
make items of options parameter optional

### DIFF
--- a/src/objects/options/options.ts
+++ b/src/objects/options/options.ts
@@ -3,12 +3,12 @@ import { LatLngBounds } from "../latLngBounds";
 import { ComponentRestrictions } from "./componentRestrictions";
 
 export class Options {
-    public bounds: LatLngBounds;
-    public componentRestrictions: ComponentRestrictions;
-    public types: string[];
-    public fields: string[];
-    public strictBounds: boolean;
-    public origin: LatLng;
+    public bounds?: LatLngBounds;
+    public componentRestrictions?: ComponentRestrictions;
+    public types?: string[];
+    public fields?: string[];
+    public strictBounds?: boolean;
+    public origin?: LatLng;
     public constructor(opt?: Partial<Options>) {
         if (!opt)
             return;


### PR DESCRIPTION
### issue: options not working with Angular 11 #91

### i make all variables of options class optionnal by adding ? behind