### PR TITLE
Fixed type to correspond to official documentation

### DIFF
--- a/src/objects/options/componentRestrictions.ts
+++ b/src/objects/options/componentRestrictions.ts
@@ -1,5 +1,5 @@
 export class ComponentRestrictions {
-    public country: string;
+    public country: string | string[];
 
     constructor(obj?: Partial<ComponentRestrictions>) {
         if (!obj)


### PR DESCRIPTION
See: https://developers.google.com/maps/documentation/javascript/reference/places-autocomplete-service#ComponentRestrictions. The type is clearly stated as string | Array<string>.